### PR TITLE
report sixel capability

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -29,7 +29,7 @@ char *scroll = NULL;
 char *stty_args = "stty raw pass8 nl -echo -iexten -cstopb 38400";
 
 /* identification sequence returned in DA and DECID */
-char *vtiden = "\033[?6c";
+char *vtiden = "\033[?63;4c";
 
 /* Kerning / character bounding-box multipliers */
 static float cwscale = 1.0;

--- a/config.h
+++ b/config.h
@@ -24,7 +24,7 @@ char *scroll = NULL;
 char *stty_args = "stty raw pass8 nl -echo -iexten -cstopb 38400";
 
 /* identification sequence returned in DA and DECID */
-char *vtiden = "\033[?6c";
+char *vtiden = "\033[?63;4c";
 
 /* Kerning / character bounding-box multipliers */
 static float cwscale = 1.0;


### PR DESCRIPTION
fixes #34, fixes https://github.com/hackerb9/lsix/issues/56

the "4" signals (depending on the first number) that this terminal is capable of displaying sixel graphics.
"6" or now "63" tells what kind of terminal it is.

https://www.xfree86.org/current/ctlseqs.html
https://terminalguide.namepad.de/seq/csi_sc/
https://vt100.net/docs/vt510-rm/DA1.html

for comparison:
mlterm replies with: "\033[?63;1;2;3;4;6;7;15;18;22;29c"
xterm (with sixel support enabled): "\033[?63;1;2;4;6;9;15;16;22;28c"
