### PR TITLE
Control + Backspace to delete previous word

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -454,6 +454,7 @@ static Key key[] = {
   { XK_Delete,        XK_ANY_MOD,     "\033[3~",      +1,    0},
   { XK_BackSpace,     XK_NO_MOD,      "\177",          0,    0},
   { XK_BackSpace,     Mod1Mask,       "\033\177",      0,    0},
+  { XK_BackSpace,     ControlMask,    "\x17",          0,    0},
   { XK_Home,          ShiftMask,      "\033[2J",       0,   -1},
   { XK_Home,          ShiftMask,      "\033[1;2H",     0,   +1},
   { XK_Home,          XK_ANY_MOD,     "\033[H",        0,   -1},


### PR DESCRIPTION
# Summary

Before then default st was using combinations like: `ctrl + alt + h` or `alt + backspace` to delete the previous word.

This is a common problem in terminal emulators. (See [0])

All of these problems are solved by remapping the keybinding (In our case its `ctrl + backspace`)

So here is the mapping I added:

```c
static Key key[] = {
  /*
      ...
  */
  /* keysym           mask            string      appkey appcursor */
  { XK_BackSpace,     ControlMask,    "\x17",          0,    0},
  /*
      ...
  */
}
```


Which adresses: #51


[0]:
    - [Kitty](https://github.com/kovidgoyal/kitty/discussions/3286)
    - [Alacritty](https://www.reddit.com/r/vim/comments/s1jvmb/comment/igkfckb/?utm_source=share&utm_medium=web2x&context=3)
    - [Terminal](https://github.com/microsoft/terminal/issues/755)

So on ...
