### PR TITLE
Fixes window not closing (#63)

### DIFF
--- a/st.c
+++ b/st.c
@@ -965,8 +965,14 @@ ttyresize(int tw, int th)
 void
 ttyhangup()
 {
+	/* disable signal handler (fixes window not closing) */
+	signal(SIGCHLD, SIG_IGN);
+
 	/* Send SIGHUP to shell */
 	kill(pid, SIGHUP);
+
+	/* forcefully die */
+	die("tty was hung up\n");
 }
 
 int


### PR DESCRIPTION
This PR fixes the issue #63 where the st window doesn't close after getting killed by the Wayland compositor.
Important notes about this PR and the issue itself:
- I'm not sure this issue is specific to Wayland, since it seems to be only related to how the signal handling is done
- I'm not sure why the window closes normally on standard st and not here, since I didn't find any changes on how the process dies/how signal handling is done
- I have not tried this in other Linux distributions (perhaps a problem with my Linux distribution or my kernel version is what is causing the issue in the first place)
- The `ttyhangup` function (triggered after the client receives a `WM_DELETE_WINDOW` message) doesn't force the process to die immediately, instead it sends a `SIGHUP` to the shell process, which causes the `sigchld()` handler to catch it in the parent process and make the process die afterwards. For some reason the process seems to get stuck at the `exit(1)` and doesn't die, and disabling the signal handling and forcing it to die fixed the issue for me.

I'm not going to push for this PR to get merged, since I'm not really sure why the original dying method doesn't work in the first place. Should be good enough for somebody else facing the issue and wants a fix, though.